### PR TITLE
fixes #9 README files and recursive depth swap 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Or, search the [releases in this repository](https://github.com/kieran-osgood/vs
 
 | Name                                               | Description                                    | Default Value           |
 | -------------------------------------------------- | ---------------------------------------------- | ----------------------- |
-| `vscode-open-files-in-directory.maxFiles`          | Maximum depth to traverse through subfolders:  |         `10`            |
-| `vscode-open-files-in-directory.maxRecursiveDepth` | Maximum number of files to open in one action: |          `1`            |
+| `vscode-open-files-in-directory.maxFiles`          | Maximum number of files to open in one action: |         `10`            |
+| `vscode-open-files-in-directory.maxRecursiveDepth` | Maximum depth to traverse through subfolders:  |          `1`            |
 ## Known Issues
 
 None currently 👀


### PR DESCRIPTION
This PR fixes the error on the README where the description of maximum number of files and recursive depth is swapped.